### PR TITLE
Add app.kubernetes.io/name label

### DIFF
--- a/helm/newrelic-logging/Chart.yaml
+++ b/helm/newrelic-logging/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart to deploy New Relic Kubernetes Logging as a DaemonSet
 name: newrelic-logging
-version: 1.0.0
+version: 1.0.1
 home: https://github.com/newrelic/kubernetes-logging
 icon: https://newrelic.com/assets/newrelic/source/NewRelic-logo-square.svg
 maintainers:

--- a/helm/newrelic-logging/templates/_helpers.tpl
+++ b/helm/newrelic-logging/templates/_helpers.tpl
@@ -26,6 +26,7 @@ app: {{ template "newrelic.name" . }}
 chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
 heritage: {{.Release.Service }}
 release: {{.Release.Name }}
+app.kubernetes.io/name: {{ template "newrelic.name" . }}
 {{- end }}
 
 {{/*

--- a/new-relic-fluent-plugin.yml
+++ b/new-relic-fluent-plugin.yml
@@ -8,6 +8,7 @@ metadata:
     version: v1
     kubernetes.io/cluster-service: "true"
     name: newrelic-logging
+    app.kubernetes.io/name: newrelic-logging
 spec:
   selector:
     matchLabels:
@@ -19,6 +20,7 @@ spec:
         version: v1
         kubernetes.io/cluster-service: "true"
         name: newrelic-logging
+        app.kubernetes.io/name: newrelic-logging
     spec:
       serviceAccountName: newrelic-logging
       containers:


### PR DESCRIPTION
FSI plans on using this label to more accurately detect whether `newrelic-logging` is installed in their cluster. This way the click throughs can also work with images that are based on this one.

We chose `app.kubernetes.io/name` because it's a [common label](https://kubernetes.io/docs/concepts/overview/working-with-objects/common-labels/#labels)