### PR TITLE
Add ability for kubernetes pods to exclude themselves and suggest parser

### DIFF
--- a/fluent-conf.yml
+++ b/fluent-conf.yml
@@ -35,10 +35,12 @@ data:
 
   filter-kubernetes.conf: |
     [FILTER]
-        Name           kubernetes
-        Match          kube.*
-        Kube_URL       https://kubernetes.default.svc.cluster.local:443
-        Merge_JSON_Log Off
+        Name                kubernetes
+        Match               kube.*
+        Kube_URL            https://kubernetes.default.svc.cluster.local:443
+        Merge_JSON_Log      Off
+        K8S-Logging.Exclude On
+        K8S-Logging.Parser  On
 
   output-newrelic.conf: |
     [OUTPUT]

--- a/helm/newrelic-logging/templates/configmap.yaml
+++ b/helm/newrelic-logging/templates/configmap.yaml
@@ -33,10 +33,12 @@ data:
 
   filter-kubernetes.conf: |
     [FILTER]
-        Name           kubernetes
-        Match          kube.*
-        Kube_URL       https://kubernetes.default.svc.cluster.local:443
-        Merge_JSON_Log Off
+        Name                kubernetes
+        Match               kube.*
+        Kube_URL            https://kubernetes.default.svc.cluster.local:443
+        Merge_JSON_Log      Off
+        K8S-Logging.Exclude On
+        K8S-Logging.Parser  On
 
   output-newrelic.conf: |
     [OUTPUT]


### PR DESCRIPTION
The fluentbit kubernetes `[FILTER]` block has two options which we will find useful - presumably other clients will as well. The first is `K8S-Logging.Exclude`. It allows developers to exclude certain pods from logging by applying a pod annotation `fluentbit.io/exclude: "true"`. This gives the ability to exclude apps that have overly-chatty or sensitive logs they don't wish to send to New Relic (currently a blocker for us).

The next option, `K8S-Logging.Parser`, allows developers to designate a fluentbit parser for their specific app.

Source:
https://github.com/fluent/fluent-bit-docs/blob/master/filter/kubernetes.md