### PR TITLE
Update namespace to not conflict with newrelic-infra

### DIFF
--- a/helm/newrelic-logging/Chart.yaml
+++ b/helm/newrelic-logging/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart to deploy New Relic Kubernetes Logging as a DaemonSet
 name: newrelic-logging
-version: 1.0.1
+version: 1.0.2
 home: https://github.com/newrelic/kubernetes-logging
 icon: https://newrelic.com/assets/newrelic/source/NewRelic-logo-square.svg
 maintainers:

--- a/helm/newrelic-logging/templates/NOTES.txt
+++ b/helm/newrelic-logging/templates/NOTES.txt
@@ -1,7 +1,7 @@
-{{- if (include "newrelic.areValuesValid" .) }}
+{{- if (include "newrelic-logging.areValuesValid" .) }}
 Your deployment of the New Relic Kubernetes Logging is complete. You can check on the progress of this by running the following command:
 
-    kubectl get daemonset -o wide -w --namespace {{ .Release.Namespace }} {{ template "newrelic.fullname" . }}
+    kubectl get daemonset -o wide -w --namespace {{ .Release.Namespace }} {{ template "newrelic-logging.fullname" . }}
 {{- else -}}
 ##############################################################################
 ####     ERROR: You did not set a license key.                            ####

--- a/helm/newrelic-logging/templates/_helpers.tpl
+++ b/helm/newrelic-logging/templates/_helpers.tpl
@@ -2,7 +2,7 @@
 {{/*
 Expand the name of the chart.
 */}}
-{{- define "newrelic.name" -}}
+{{- define "newrelic-logging.name" -}}
 {{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
@@ -10,7 +10,7 @@ Expand the name of the chart.
 Create a default fully qualified app name.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
 */}}
-{{- define "newrelic.fullname" -}}
+{{- define "newrelic-logging.fullname" -}}
 {{- $name := default .Chart.Name .Values.nameOverride -}}
 {{- if ne $name .Release.Name -}}
 {{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
@@ -21,27 +21,27 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 
 
 {{/* Generate basic labels */}}
-{{- define "newrelic.labels" }}
-app: {{ template "newrelic.name" . }}
+{{- define "newrelic-logging.labels" }}
+app: {{ template "newrelic-logging.name" . }}
 chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
 heritage: {{.Release.Service }}
 release: {{.Release.Name }}
-app.kubernetes.io/name: {{ template "newrelic.name" . }}
+app.kubernetes.io/name: {{ template "newrelic-logging.name" . }}
 {{- end }}
 
 {{/*
 Create chart name and version as used by the chart label.
 */}}
-{{- define "newrelic.chart" -}}
+{{- define "newrelic-logging.chart" -}}
 {{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
 {{/*
 Create the name of the service account to use
 */}}
-{{- define "newrelic.serviceAccountName" -}}
+{{- define "newrelic-logging.serviceAccountName" -}}
 {{- if .Values.serviceAccount.create -}}
-    {{ default (include "newrelic.fullname" .) .Values.serviceAccount.name }}
+    {{ default (include "newrelic-logging.fullname" .) .Values.serviceAccount.name }}
 {{- else -}}
     {{ default "default" .Values.serviceAccount.name }}
 {{- end -}}
@@ -51,14 +51,14 @@ Create the name of the service account to use
 {{/*
 Create the name of the fluent bit config
 */}}
-{{- define "newrelic.fluentBitConfig" -}}
-{{ template "newrelic.fullname" . }}-fluent-bit-config
+{{- define "newrelic-logging.fluentBitConfig" -}}
+{{ template "newrelic-logging.fullname" . }}-fluent-bit-config
 {{- end -}}
 
 {{/*
 Return the licenseKey
 */}}
-{{- define "newrelic.licenseKey" -}}
+{{- define "newrelic-logging.licenseKey" -}}
 {{- if .Values.global}}
   {{- if .Values.global.licenseKey }}
       {{- .Values.global.licenseKey -}}
@@ -73,7 +73,7 @@ Return the licenseKey
 {{/*
 Return the customSecretName
 */}}
-{{- define "newrelic.customSecretName" -}}
+{{- define "newrelic-logging.customSecretName" -}}
 {{- if .Values.global }}
   {{- if .Values.global.customSecretName }}
       {{- .Values.global.customSecretName -}}
@@ -88,7 +88,7 @@ Return the customSecretName
 {{/*
 Return the customSecretKey
 */}}
-{{- define "newrelic.customSecretKey" -}}
+{{- define "newrelic-logging.customSecretKey" -}}
 {{- if .Values.global }}
   {{- if .Values.global.customSecretKey }}
       {{- .Values.global.customSecretKey -}}
@@ -103,9 +103,9 @@ Return the customSecretKey
 {{/*
 Returns if the template should render, it checks if the required values are set.
 */}}
-{{- define "newrelic.areValuesValid" -}}
-{{- $licenseKey := include "newrelic.licenseKey" . -}}
-{{- $customSecretName := include "newrelic.customSecretName" . -}}
-{{- $customSecretKey := include "newrelic.customSecretKey" . -}}
+{{- define "newrelic-logging.areValuesValid" -}}
+{{- $licenseKey := include "newrelic-logging.licenseKey" . -}}
+{{- $customSecretName := include "newrelic-logging.customSecretName" . -}}
+{{- $customSecretKey := include "newrelic-logging.customSecretKey" . -}}
 {{- and (or $licenseKey (and $customSecretName $customSecretKey))}}
 {{- end -}}

--- a/helm/newrelic-logging/templates/clusterrole.yaml
+++ b/helm/newrelic-logging/templates/clusterrole.yaml
@@ -2,8 +2,8 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  labels: {{ include "newrelic.labels" . | indent 4 }}
-  name: {{ template "newrelic.fullname" . }}
+  labels: {{ include "newrelic-logging.labels" . | indent 4 }}
+  name: {{ template "newrelic-logging.fullname" . }}
 rules:
   - apiGroups: [""]
     resources:

--- a/helm/newrelic-logging/templates/clusterrolebinding.yaml
+++ b/helm/newrelic-logging/templates/clusterrolebinding.yaml
@@ -2,14 +2,14 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  labels: {{ include "newrelic.labels" . | indent 4 }}
-  name: {{ template "newrelic.fullname" . }}
+  labels: {{ include "newrelic-logging.labels" . | indent 4 }}
+  name: {{ template "newrelic-logging.fullname" . }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: {{ template "newrelic.fullname" . }}
+  name: {{ template "newrelic-logging.fullname" . }}
 subjects:
 - kind: ServiceAccount
-  name: {{ template "newrelic.serviceAccountName" . }}
+  name: {{ template "newrelic-logging.serviceAccountName" . }}
   namespace: {{ .Release.Namespace }}
 {{- end -}}

--- a/helm/newrelic-logging/templates/configmap.yaml
+++ b/helm/newrelic-logging/templates/configmap.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  labels: {{ include "newrelic.labels" . | indent 4 }}
-  name: {{ template "newrelic.fluentBitConfig" . }}
+  labels: {{ include "newrelic-logging.labels" . | indent 4 }}
+  name: {{ template "newrelic-logging.fluentBitConfig" . }}
 data:
   # Configuration files: server, input, filters and output
   # ======================================================

--- a/helm/newrelic-logging/templates/daemonset.yaml
+++ b/helm/newrelic-logging/templates/daemonset.yaml
@@ -1,15 +1,15 @@
-{{- if (include "newrelic.areValuesValid" .) }}
+{{- if (include "newrelic-logging.areValuesValid" .) }}
 apiVersion: apps/v1beta2
 kind: DaemonSet
 metadata:
-  labels: {{ include "newrelic.labels" . | indent 4 }}
-  name: {{ template "newrelic.fullname" . }}
+  labels: {{ include "newrelic-logging.labels" . | indent 4 }}
+  name: {{ template "newrelic-logging.fullname" . }}
 spec:
   updateStrategy:
     type: {{ .Values.updateStrategy }}
   selector:
     matchLabels:
-      app: {{ template "newrelic.name" . }}
+      app: {{ template "newrelic-logging.name" . }}
       release: {{.Release.Name }}
   template:
     metadata:
@@ -18,23 +18,23 @@ spec:
 {{ toYaml .Values.podAnnotations | indent 8}}
     {{- end }}
       labels:
-        app: {{ template "newrelic.name" . }}
+        app: {{ template "newrelic-logging.name" . }}
         release: {{.Release.Name }}
         {{- if .Values.podLabels}}
         {{ toYaml .Values.podLabels }}
         {{- end }}
     spec:
-      serviceAccountName: {{ template "newrelic.serviceAccountName" . }}
+      serviceAccountName: {{ template "newrelic-logging.serviceAccountName" . }}
       hostNetwork: true # This option is a requirement for the Infrastructure Agent to report the proper hostname in New Relic.
       dnsPolicy: ClusterFirstWithHostNet
       terminationGracePeriodSeconds: 10
       containers:
-        - name: {{ template "newrelic.name" . }}
+        - name: {{ template "newrelic-logging.name" . }}
           image: {{ .Values.image.repository }}:{{ .Values.image.tag }}
           imagePullPolicy: "{{ .Values.image.pullPolicy }}"
           env:
             - name: ENDPOINT
-              {{- if eq (substr 0 2 (include "newrelic.licenseKey" .)) "eu" }}
+              {{- if eq (substr 0 2 (include "newrelic-logging.licenseKey" .)) "eu" }}
               value: "https://log-api.eu.newrelic.com/log/v1"
               {{- else }}
               value: "https://log-api.newrelic.com/log/v1"
@@ -44,12 +44,12 @@ spec:
             - name: LICENSE_KEY
               valueFrom:
                 secretKeyRef:
-                  {{- if (include "newrelic.licenseKey" .) }}
-                  name: {{ template "newrelic.fullname" . }}-config
+                  {{- if (include "newrelic-logging.licenseKey" .) }}
+                  name: {{ template "newrelic-logging.fullname" . }}-config
                   key: license
                   {{- else }}
-                  name: {{ include "newrelic.customSecretName" . }}
-                  key: {{ include "newrelic.customSecretKey" . }}
+                  name: {{ include "newrelic-logging.customSecretName" . }}
+                  key: {{ include "newrelic-logging.customSecretKey" . }}
                   {{- end }}
             - name: BUFFER_SIZE
               value: {{ .Values.fluentBit.bufferSize | quote }}
@@ -77,7 +77,7 @@ spec:
       volumes:
         - name: fluent-bit-config
           configMap:
-            name: {{ template "newrelic.fluentBitConfig" . }}
+            name: {{ template "newrelic-logging.fluentBitConfig" . }}
         - name: var
           hostPath:
             path: /var

--- a/helm/newrelic-logging/templates/secret.yaml
+++ b/helm/newrelic-logging/templates/secret.yaml
@@ -1,10 +1,10 @@
-{{- $licenseKey := include "newrelic.licenseKey" . -}}
+{{- $licenseKey := include "newrelic-logging.licenseKey" . -}}
 {{- if $licenseKey }}
 apiVersion: v1
 kind: Secret
 metadata:
-  labels: {{ include "newrelic.labels" . | indent 4 }}
-  name: {{ template "newrelic.fullname" . }}-config
+  labels: {{ include "newrelic-logging.labels" . | indent 4 }}
+  name: {{ template "newrelic-logging.fullname" . }}-config
 type: Opaque
 data:
   license: {{ $licenseKey | b64enc }}

--- a/helm/newrelic-logging/templates/serviceaccount.yaml
+++ b/helm/newrelic-logging/templates/serviceaccount.yaml
@@ -3,9 +3,9 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   labels:
-    app: {{ template "newrelic.name" . }}
-    chart: {{ template "newrelic.chart" . }}
+    app: {{ template "newrelic-logging.name" . }}
+    chart: {{ template "newrelic-logging.chart" . }}
     heritage: "{{ .Release.Service }}"
     release: "{{ .Release.Name }}"
-  name: {{ template "newrelic.serviceAccountName" . }}
+  name: {{ template "newrelic-logging.serviceAccountName" . }}
 {{- end -}}


### PR DESCRIPTION
Currently the helpers in the helm chart use the same namespace as the `newrelic-infra` helm chart, which causes a conflict in our config generator which bundles all our helm charts.

You can read more about the issue here: https://github.com/helm/helm/issues/2216
The recommended solution is to namespace your helpers so I have made an other pull request to update the current namespace from `newrelic` to `newrelic-logging`