### PR TITLE
Add K8s Cluster Name to logs for improved filtering

### DIFF
--- a/fluent-conf.yml
+++ b/fluent-conf.yml
@@ -35,6 +35,11 @@ data:
 
   filter-kubernetes.conf: |
     [FILTER]
+        Name record_modifier
+        Match  *
+        Record cluster_name ${CLUSTER_NAME}
+
+    [FILTER]
         Name           kubernetes
         Match          kube.*
         Kube_URL       https://kubernetes.default.svc.cluster.local:443

--- a/fluent-conf.yml
+++ b/fluent-conf.yml
@@ -36,7 +36,7 @@ data:
   filter-kubernetes.conf: |
     [FILTER]
         Name record_modifier
-        Match  *
+        Match *
         Record cluster_name ${CLUSTER_NAME}
 
     [FILTER]

--- a/new-relic-fluent-plugin.yml
+++ b/new-relic-fluent-plugin.yml
@@ -32,6 +32,8 @@ spec:
             value: "kubernetes"
           - name: LICENSE_KEY
             value: <YOUR_LICENSE_KEY>
+          - name: CLUSTER_NAME
+            value: <YOUR CLUSTER NAME>
           - name: BUFFER_SIZE
             value: "256000"
           - name: MAX_RECORDS


### PR DESCRIPTION
It's possible (and very likely) customers will have more than one K8s cluster running the New Relic logs integration.  This change appends a simple **cluster_name** field that contains the value from the CLUSTER_NAME env variable in `new-relic-fluent-plugin.yml`.  This provides a more useful filtering experience in New Relic Logs.