### PR TITLE
Explicitly define the namespace in manifests

### DIFF
--- a/helm/newrelic-logging/templates/configmap.yaml
+++ b/helm/newrelic-logging/templates/configmap.yaml
@@ -3,6 +3,7 @@ kind: ConfigMap
 metadata:
   labels: {{ include "newrelic-logging.labels" . | indent 4 }}
   name: {{ template "newrelic-logging.fluentBitConfig" . }}
+  namespace: {{ .Release.Namespace }}
 data:
   # Configuration files: server, input, filters and output
   # ======================================================

--- a/helm/newrelic-logging/templates/daemonset.yaml
+++ b/helm/newrelic-logging/templates/daemonset.yaml
@@ -4,6 +4,7 @@ kind: DaemonSet
 metadata:
   labels: {{ include "newrelic-logging.labels" . | indent 4 }}
   name: {{ template "newrelic-logging.fullname" . }}
+  namespace: {{ .Release.Namespace }}
 spec:
   updateStrategy:
     type: {{ .Values.updateStrategy }}

--- a/helm/newrelic-logging/templates/daemonset.yaml
+++ b/helm/newrelic-logging/templates/daemonset.yaml
@@ -1,5 +1,5 @@
 {{- if (include "newrelic-logging.areValuesValid" .) }}
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   labels: {{ include "newrelic-logging.labels" . | indent 4 }}

--- a/helm/newrelic-logging/templates/secret.yaml
+++ b/helm/newrelic-logging/templates/secret.yaml
@@ -5,6 +5,7 @@ kind: Secret
 metadata:
   labels: {{ include "newrelic-logging.labels" . | indent 4 }}
   name: {{ template "newrelic-logging.fullname" . }}-config
+  namespace: {{ .Release.Namespace }}
 type: Opaque
 data:
   license: {{ $licenseKey | b64enc }}

--- a/helm/newrelic-logging/templates/serviceaccount.yaml
+++ b/helm/newrelic-logging/templates/serviceaccount.yaml
@@ -8,4 +8,5 @@ metadata:
     heritage: "{{ .Release.Service }}"
     release: "{{ .Release.Name }}"
   name: {{ template "newrelic-logging.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
 {{- end -}}


### PR DESCRIPTION
This is needed in order to render the templates with the correct namespace when passed the --namespace flag. This is required for tools like Spinnaker.

This fixes an issue when the template is render with `helm template <NAME> . --namespace foo > template.yaml` and installed with `kubectl apply -f template.yaml -n bar`, that will install all the resources in the namespace `bar` but the cluster role binding will specified a service account subject in the `foo` namespace. We are currently being affected by this issue in the installation wizard for the newrelic k8s integration. 

This doesn't affect installing directly from helm since helm adds the value directly from the --namespace flag.