### PR TITLE
Fix using secret for EU accounts

### DIFF
--- a/helm/newrelic-logging/templates/daemonset.yaml
+++ b/helm/newrelic-logging/templates/daemonset.yaml
@@ -35,7 +35,9 @@ spec:
           imagePullPolicy: "{{ .Values.image.pullPolicy }}"
           env:
             - name: ENDPOINT
-              {{- if eq (substr 0 2 (include "newrelic-logging.licenseKey" .)) "eu" }}
+              {{- if .Values.endpoint }}
+              value: {{ .Values.endpoint }}
+              {{- else if eq (substr 0 2 (include "newrelic-logging.licenseKey" .)) "eu" }}
               value: "https://log-api.eu.newrelic.com/log/v1"
               {{- else }}
               value: "https://log-api.newrelic.com/log/v1"

--- a/helm/newrelic-logging/values.yaml
+++ b/helm/newrelic-logging/values.yaml
@@ -12,6 +12,12 @@
 #   licenseKey:
 #   customSecretName:
 #   customSecretKey:
+#
+# IMPORTANT: if you use a kubernetes secret to specify the license,
+# you have to manually provide the correct endpoint depending on
+# whether your account is for the EU region or not.
+#
+# endpoint: https://log-api.newrelic.com/log/v1
 
 fluentBit:
   bufferSize: "256000"
@@ -64,4 +70,3 @@ tolerations:
     effect: "NoExecute"
 
 updateStrategy: RollingUpdate
-


### PR DESCRIPTION
* as the endpoint is auto-determined by the provided
  license key, but secrets are opaque to helm,
  the wrong URL would be used when using the license
  key from a secret.
* extend documentation and values.yaml to allow configuration
  of the ENDPOINT environment variable